### PR TITLE
Mentalist path

### DIFF
--- a/PATHOGIST
+++ b/PATHOGIST
@@ -190,7 +190,7 @@ def install_mentalist():
     #pkg = '[ "Distributed", "ArgParse", "BioSequences", "JSON", "DataStructures", "JLD", "GZip", "Blosc", "FileIO", "TextWrap", "LightXML"]'
     #julia_command = julia_dir + '/julia-1.1.0/bin/julia'+' -e \'import Pkg; Pkg.add("%s")\'' % (pkg)
     #subprocess.call(julia_command, shell=True)
-    if os.path.isfile(julia_dir + '/MentaLiST-65451e75e5cfd168c23989a0ef50fcf545cc8e57/src/MentaLiST.jl') == False:
+    if os.path.isfile(julia_dir + '/MentaLiST-65451e7/src/MentaLiST.jl') == False:
         subprocess.call(['wget', '-q', '-x', '-P', julia_dir, 
             'https://github.com/WGS-TB/MentaLiST/archive/65451e7.zip'])
         subprocess.call(['unzip', 
@@ -212,7 +212,7 @@ def run_mentalist(mentalist_args,forward_reads_paths,reverse_reads_paths,threads
         if mentalist_args['db_loc'][subcmd] == 1:
             subcmd_options = mentalist_args[subcmd]['options']
             mentalist_command = [julia_dir + '/julia-1.1.0/bin/julia',
-                                 julia_dir + '/MentaLiST-65451e75e5cfd168c23989a0ef50fcf545cc8e57/src/MentaLiST.jl',
+                                 julia_dir + '/MentaLiST-65451e7/src/MentaLiST.jl',
                                  subcmd,
                                  '--db','%s' % db_path,
                                  '--threads','%s' % threads,

--- a/PATHOGIST
+++ b/PATHOGIST
@@ -195,6 +195,8 @@ def install_mentalist():
             'https://github.com/WGS-TB/MentaLiST/archive/65451e7.zip'])
         subprocess.call(['unzip', 
             julia_dir+'/github.com/WGS-TB/MentaLiST/archive/65451e7.zip', '-d', julia_dir])
+        subprocess.call(['mv', 
+            julia_dir+'/MentaLiST-65451e7*', julia_dir+'/MentaLiST-65451e7'])
     
     
 

--- a/PATHOGIST
+++ b/PATHOGIST
@@ -252,7 +252,7 @@ def run_mentalist_call(mentalist_args, forward_reads_paths, reverse_reads_paths,
         call_path = '%s/%s_mlst.call' % (temp_dir,accession)
         mentalist_calls_paths.append(call_path)
         call_command = [julia_dir + '/julia-1.1.0/bin/julia',
-                        julia_dir + '/MentaLiST-65451e75e5cfd168c23989a0ef50fcf545cc8e57/src/MentaLiST.jl',
+                        julia_dir + '/MentaLiST-65451e7/src/MentaLiST.jl',
                         'call']
         call_command.extend(['--db', db_path])
         call_command.extend(['-o', call_path])

--- a/tests/unit_tests/test_cluster.py
+++ b/tests/unit_tests/test_cluster.py
@@ -32,7 +32,7 @@ class ClusterTest(unittest.TestCase):
     def test_correlation(self):
         true_clustering_path = 'tests/unit_tests/test_data/cluster/yersinia_true_clustering.tsv'
         true_clustering = pathogist.io.open_clustering_file(true_clustering_path)
-        clustering = pathogist.cluster.correlation(self.mlst_dist,500)
+        clustering = pathogist.cluster.c4_correlation(self.mlst_dist,500)
         samples = list(clustering.index.values)
         self.assertEqual(pathogist.cluster.adjusted_rand_index(clustering.loc[samples],
                                                                true_clustering.loc[samples]),1)


### PR DESCRIPTION
This PR contains fixes to mentalist installation and cplex error. cplex error is a result of calling the correlation function directly without cplex installation. PATHOGIST when ran with the entire pipeline calls c4_correlation in the absence of cplex. The mentalist installation problem probably has to do with a new version unzip program. I'm guessing the default vm changed.  It seems to have removed the second half of the shasum in the directory name.